### PR TITLE
BiIndex

### DIFF
--- a/python/bistring/_alignment.py
+++ b/python/bistring/_alignment.py
@@ -8,7 +8,7 @@ __all__ = ['Alignment']
 import bisect
 from typing import Any, Callable, Iterable, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union, cast, overload
 
-from ._typing import AnyBounds, Bounds, Index, Range
+from ._typing import AnyBounds, BiIndex, Bounds, Index, Range
 
 
 T = TypeVar('T')
@@ -77,7 +77,7 @@ class Alignment:
     _original: List[int]
     _modified: List[int]
 
-    def __init__(self, values: Iterable[Bounds]):
+    def __init__(self, values: Iterable[BiIndex]):
         """
         :param values:
             The sequence of aligned indices.  Each element should be a tuple ``(x, y)``, where `x` is the original
@@ -273,7 +273,7 @@ class Alignment:
         return result
 
     @classmethod
-    def _infer_recursive(cls, original: Sequence[T], modified: Sequence[U], cost_fn: CostFn[T, U]) -> List[Bounds]:
+    def _infer_recursive(cls, original: Sequence[T], modified: Sequence[U], cost_fn: CostFn[T, U]) -> List[BiIndex]:
         """
         Hirschberg's algorithm for computing optimal alignments in linear space.
 
@@ -341,19 +341,19 @@ class Alignment:
             result = cls._infer_recursive(original, modified, real_cost_fn)
             return Alignment(result)
 
-    def __iter__(self) -> Iterator[Tuple[int, int]]:
+    def __iter__(self) -> Iterator[BiIndex]:
         return zip(self._original, self._modified)
 
     def __len__(self) -> int:
         return len(self._original)
 
     @overload
-    def __getitem__(self, index: int) -> Bounds: ...
+    def __getitem__(self, index: int) -> BiIndex: ...
 
     @overload
     def __getitem__(self, index: slice) -> Alignment: ...
 
-    def __getitem__(self, index: Index) -> Union[Bounds, Alignment]:
+    def __getitem__(self, index: Index) -> Union[BiIndex, Alignment]:
         """
         Indexing an alignment returns the nth pair of aligned positions:
 

--- a/python/bistring/_builder.py
+++ b/python/bistring/_builder.py
@@ -8,7 +8,7 @@ from typing import Iterable, List, Match, Optional
 from ._alignment import Alignment
 from ._bistr import bistr, String
 from ._regex import compile_regex, expand_template
-from ._typing import Bounds, Regex, Replacement
+from ._typing import BiIndex, Regex, Replacement
 
 
 class BistrBuilder:
@@ -57,7 +57,7 @@ class BistrBuilder:
 
     _original: bistr
     _modified: List[str]
-    _alignment: List[Bounds]
+    _alignment: List[BiIndex]
     _opos: int
     _mpos: int
 

--- a/python/bistring/_typing.py
+++ b/python/bistring/_typing.py
@@ -4,6 +4,8 @@
 from typing import Callable, Match, Pattern, Tuple, Union
 
 
+BiIndex = Tuple[int, int]
+
 Bounds = Tuple[int, int]
 
 AnyBounds = Union[int, range, slice, Bounds]

--- a/python/tests/test_alignment.py
+++ b/python/tests/test_alignment.py
@@ -18,6 +18,27 @@ def test_empty():
     assert alignment.modified_bounds(0, 0) == (0, 0)
 
 
+def test_indexing():
+    data = [
+        (0, 1),
+        (1, 2),
+        (2, 4),
+        (3, 8),
+        (4, 16),
+    ]
+    length = len(data)
+    alignment = Alignment(data)
+
+    assert len(alignment) == length
+
+    for i in range(length):
+        assert alignment[i] == data[i]
+        assert alignment[i - length] == data[i - length]
+
+        for j in range(i + 1, length + 1):
+            assert list(alignment[i:j]) == data[i:j]
+
+
 def test_identity():
     alignment = Alignment.identity(1, 16)
 


### PR DESCRIPTION
python: Use a separate type for pairs of aligned indices

Previously we were using Bounds = Tuple[int, int] for both ranges and
pair of indices.  Clarify the distinction with a new BiIndex type like
the TypeScript implementation.
